### PR TITLE
Don't use deprecated boolean but bool

### DIFF
--- a/Adafruit_MAX31865.cpp
+++ b/Adafruit_MAX31865.cpp
@@ -42,7 +42,7 @@ Adafruit_MAX31865::Adafruit_MAX31865(int8_t spi_cs) {
   _sclk = _miso = _mosi = -1;
 }
 
-boolean Adafruit_MAX31865::begin(max31865_numwires_t wires) {
+bool Adafruit_MAX31865::begin(max31865_numwires_t wires) {
   pinMode(_cs, OUTPUT);
   digitalWrite(_cs, HIGH);
 
@@ -82,7 +82,7 @@ void Adafruit_MAX31865::clearFault(void) {
   writeRegister8(MAX31856_CONFIG_REG, t);
 }
 
-void Adafruit_MAX31865::enableBias(boolean b) {
+void Adafruit_MAX31865::enableBias(bool b) {
   uint8_t t = readRegister8(MAX31856_CONFIG_REG);
   if (b) {
     t |= MAX31856_CONFIG_BIAS;       // enable bias
@@ -92,7 +92,7 @@ void Adafruit_MAX31865::enableBias(boolean b) {
   writeRegister8(MAX31856_CONFIG_REG, t);
 }
 
-void Adafruit_MAX31865::autoConvert(boolean b) {
+void Adafruit_MAX31865::autoConvert(bool b) {
   uint8_t t = readRegister8(MAX31856_CONFIG_REG);
   if (b) {
     t |= MAX31856_CONFIG_MODEAUTO;       // enable autoconvert

--- a/Adafruit_MAX31865.h
+++ b/Adafruit_MAX31865.h
@@ -66,7 +66,7 @@ class Adafruit_MAX31865 {
   Adafruit_MAX31865(int8_t spi_cs, int8_t spi_mosi, int8_t spi_miso, int8_t spi_clk);
   Adafruit_MAX31865(int8_t spi_cs);
 
-  boolean begin(max31865_numwires_t x = MAX31865_2WIRE);
+  bool begin(max31865_numwires_t x = MAX31865_2WIRE);
 
   uint8_t readFault(void);
   void clearFault(void);
@@ -74,8 +74,8 @@ class Adafruit_MAX31865 {
 
 
   void setWires(max31865_numwires_t wires);
-  void autoConvert(boolean b);
-  void enableBias(boolean b);
+  void autoConvert(bool b);
+  void enableBias(bool b);
 
   float temperature(float RTDnominal, float refResistor);
 


### PR DESCRIPTION
`boolean` is deprecated and it give a lot of warnings.

> Adafruit_MAX31865\Adafruit_MAX31865.h:69:55: warning: 'boolean' is deprecated [-Wdeprecated-declarations]

You really should enable the warning on your side since this isn't the first of your libraries which uses it (I also pushed the same fix on neopixel)
Have a nice day :)