### PR TITLE
Fix NULL-pointer assignment to object

### DIFF
--- a/Adafruit_MAX31865.cpp
+++ b/Adafruit_MAX31865.cpp
@@ -34,10 +34,9 @@
 /**************************************************************************/
 //
 Adafruit_MAX31865::Adafruit_MAX31865(int8_t spi_cs, int8_t spi_mosi,
-                                     int8_t spi_miso, int8_t spi_clk) {
-  spi_dev = Adafruit_SPIDevice(spi_cs, spi_clk, spi_miso, spi_mosi, 1000000,
-                               SPI_BITORDER_MSBFIRST, SPI_MODE1);
-}
+                                     int8_t spi_miso, int8_t spi_clk)
+    : spi_dev(spi_cs, spi_clk, spi_miso, spi_mosi, 1000000,
+              SPI_BITORDER_MSBFIRST, SPI_MODE1) {}
 
 /**************************************************************************/
 /*!
@@ -45,10 +44,8 @@ Adafruit_MAX31865::Adafruit_MAX31865(int8_t spi_cs, int8_t spi_mosi,
     @param spi_cs the SPI CS pin to use along with the default SPI device
 */
 /**************************************************************************/
-Adafruit_MAX31865::Adafruit_MAX31865(int8_t spi_cs) {
-  spi_dev =
-      Adafruit_SPIDevice(spi_cs, 1000000, SPI_BITORDER_MSBFIRST, SPI_MODE1);
-}
+Adafruit_MAX31865::Adafruit_MAX31865(int8_t spi_cs)
+    : spi_dev(spi_cs, 1000000, SPI_BITORDER_MSBFIRST, SPI_MODE1) {}
 
 /**************************************************************************/
 /*!

--- a/Adafruit_MAX31865.h
+++ b/Adafruit_MAX31865.h
@@ -81,7 +81,7 @@ public:
   float temperature(float RTDnominal, float refResistor);
 
 private:
-  Adafruit_SPIDevice spi_dev = NULL;
+  Adafruit_SPIDevice spi_dev;
 
   void readRegisterN(uint8_t addr, uint8_t buffer[], uint8_t n);
 


### PR DESCRIPTION
Analogous to the fix in https://github.com/adafruit/Adafruit-MAX31855-library/pull/42.
Fixing the same warning as described in https://github.com/adafruit/Adafruit-MAX31855-library/issues/41.

Some notes why not using a pointer to the device and creating the device on the heap in https://github.com/adafruit/Adafruit-MAX31855-library/issues/41#issuecomment-700543918

Tested on an UNO with the example.

Please wait with creating a new version. There are some more pressing problems.
