### PR TITLE
Added threshold handling

### DIFF
--- a/Adafruit_MAX31865.cpp
+++ b/Adafruit_MAX31865.cpp
@@ -61,7 +61,7 @@ bool Adafruit_MAX31865::begin(max31865_numwires_t wires) {
   setWires(wires);
   enableBias(false);
   autoConvert(false);
-  setThreshold(0, 0xFFFF);
+  setThresholds(0, 0xFFFF);
   clearFault();
 
   // Serial.print("config: ");
@@ -148,7 +148,7 @@ void Adafruit_MAX31865::enable50Hz(bool b) {
     @param upper raw upper threshold
 */
 /**************************************************************************/
-void Adafruit_MAX31865::setThreshold(uint16_t lower, uint16_t upper) {
+void Adafruit_MAX31865::setThresholds(uint16_t lower, uint16_t upper) {
   writeRegister8(MAX31865_LFAULTLSB_REG, lower & 0xFF);
   writeRegister8(MAX31865_LFAULTMSB_REG, lower >> 8);
   writeRegister8(MAX31865_HFAULTLSB_REG, upper & 0xFF);
@@ -161,7 +161,7 @@ void Adafruit_MAX31865::setThreshold(uint16_t lower, uint16_t upper) {
     @return The raw unsigned 16-bit value, NOT temperature!
 */
 /**************************************************************************/
-uint16_t Adafruit_MAX31865::lowerThreshold(void) {
+uint16_t Adafruit_MAX31865::getLowerThreshold(void) {
   return readRegister16(MAX31865_LFAULTMSB_REG);
 }
 
@@ -171,7 +171,7 @@ uint16_t Adafruit_MAX31865::lowerThreshold(void) {
     @return The raw unsigned 16-bit value, NOT temperature!
 */
 /**************************************************************************/
-uint16_t Adafruit_MAX31865::upperThreshold(void) {
+uint16_t Adafruit_MAX31865::getUpperThreshold(void) {
   return readRegister16(MAX31865_HFAULTMSB_REG);
 }
 

--- a/Adafruit_MAX31865.cpp
+++ b/Adafruit_MAX31865.cpp
@@ -91,7 +91,6 @@ void Adafruit_MAX31865::clearFault(void) {
   writeRegister8(MAX31865_CONFIG_REG, t);
 }
 
-
 /**************************************************************************/
 /*!
     @brief Enable the bias voltage on the RTD sensor

--- a/Adafruit_MAX31865.cpp
+++ b/Adafruit_MAX31865.cpp
@@ -153,7 +153,7 @@ void Adafruit_MAX31865::setThreshold(uint16_t lower, uint16_t upper) {
   writeRegister8(MAX31865_LFAULTLSB_REG, lower & 0xFF);
   writeRegister8(MAX31865_LFAULTMSB_REG, lower >> 8);
   writeRegister8(MAX31865_HFAULTLSB_REG, upper & 0xFF);
-  writeRegister8(MAX31865_HFAULTMSB_REG, upper >> 8 );
+  writeRegister8(MAX31865_HFAULTMSB_REG, upper >> 8);
 }
 
 /**************************************************************************/

--- a/Adafruit_MAX31865.cpp
+++ b/Adafruit_MAX31865.cpp
@@ -61,6 +61,7 @@ bool Adafruit_MAX31865::begin(max31865_numwires_t wires) {
   setWires(wires);
   enableBias(false);
   autoConvert(false);
+  setThreshold(0, 0xFFFF);
   clearFault();
 
   // Serial.print("config: ");
@@ -89,6 +90,7 @@ void Adafruit_MAX31865::clearFault(void) {
   t |= MAX31865_CONFIG_FAULTSTAT;
   writeRegister8(MAX31865_CONFIG_REG, t);
 }
+
 
 /**************************************************************************/
 /*!
@@ -137,6 +139,41 @@ void Adafruit_MAX31865::enable50Hz(bool b) {
     t &= ~MAX31865_CONFIG_FILT50HZ;
   }
   writeRegister8(MAX31865_CONFIG_REG, t);
+}
+
+/**************************************************************************/
+/*!
+    @brief Write the lower and upper values into the threshold fault
+    register to values as returned by readRTD()
+    @param lower raw lower threshold
+    @param upper raw upper threshold
+*/
+/**************************************************************************/
+void Adafruit_MAX31865::setThreshold(uint16_t lower, uint16_t upper) {
+  writeRegister8(MAX31865_LFAULTLSB_REG, lower & 0xFF);
+  writeRegister8(MAX31865_LFAULTMSB_REG, lower >> 8);
+  writeRegister8(MAX31865_HFAULTLSB_REG, upper & 0xFF);
+  writeRegister8(MAX31865_HFAULTMSB_REG, upper >> 8 );
+}
+
+/**************************************************************************/
+/*!
+    @brief Read the raw 16-bit lower threshold value
+    @return The raw unsigned 16-bit value, NOT temperature!
+*/
+/**************************************************************************/
+uint16_t Adafruit_MAX31865::lowerThreshold(void) {
+  return readRegister16(MAX31865_LFAULTMSB_REG);
+}
+
+/**************************************************************************/
+/*!
+    @brief Read the raw 16-bit lower threshold value
+    @return The raw unsigned 16-bit value, NOT temperature!
+*/
+/**************************************************************************/
+uint16_t Adafruit_MAX31865::upperThreshold(void) {
+  return readRegister16(MAX31865_HFAULTMSB_REG);
 }
 
 /**************************************************************************/

--- a/Adafruit_MAX31865.h
+++ b/Adafruit_MAX31865.h
@@ -73,9 +73,9 @@ public:
   void clearFault(void);
   uint16_t readRTD();
 
-  void setThreshold(uint16_t lower, uint16_t upper);
-  uint16_t lowerThreshold(void);
-  uint16_t upperThreshold(void);
+  void setThresholds(uint16_t lower, uint16_t upper);
+  uint16_t getLowerThreshold(void);
+  uint16_t getUpperThreshold(void);
 
   void setWires(max31865_numwires_t wires);
   void autoConvert(bool b);

--- a/Adafruit_MAX31865.h
+++ b/Adafruit_MAX31865.h
@@ -73,6 +73,10 @@ public:
   void clearFault(void);
   uint16_t readRTD();
 
+  void setThreshold(uint16_t lower, uint16_t upper);
+  uint16_t lowerThreshold(void);
+  uint16_t upperThreshold(void);
+
   void setWires(max31865_numwires_t wires);
   void autoConvert(bool b);
   void enable50Hz(bool b);


### PR DESCRIPTION
- Added set and get method for threshold value.
- Thresholds intialized to 0x0000 and 0xffff
- This prevents unwanted faults (fault codes MAX31865_FAULT_LOWTHRESH and MAX31865_FAULT_HIGHTHRESH) because by default upper/lower thresholds are initialized by the chip with 0xffff which causes always a fault with the lower threshold.
- I do not See any limitations
- Code was tested in my own application (where the above mentioned fault code was always raised)