### PR TITLE
create subfunctions for readRTD

### DIFF
--- a/Adafruit_MAX31865.cpp
+++ b/Adafruit_MAX31865.cpp
@@ -217,17 +217,46 @@ float Adafruit_MAX31865::temperature(float RTDnominal, float refResistor) {
 */
 /**************************************************************************/
 uint16_t Adafruit_MAX31865::readRTD(void) {
+  readRTDPrepare();
+  delay(10);
+  readRTDSend();
+  delay(65);
+  return readRTDGet();
+}
+
+/**************************************************************************/
+/*!
+    @brief Prepare for reading raw 16-bit value from the RTD_REG
+    in one shot mode
+*/
+/**************************************************************************/
+void Adafruit_MAX31865::readRTDPrepare(void) {
   clearFault();
   enableBias(true);
-  delay(10);
+}
+
+/**************************************************************************/
+/*!
+    @brief Send command for reading raw 16-bit value from the RTD_REG
+    in one shot mode
+*/
+/**************************************************************************/
+void Adafruit_MAX31865::readRTDSend(void) {
   uint8_t t = readRegister8(MAX31865_CONFIG_REG);
   t |= MAX31865_CONFIG_1SHOT;
   writeRegister8(MAX31865_CONFIG_REG, t);
-  delay(65);
+}
 
+/**************************************************************************/
+/*!
+    @brief Get the raw 16-bit value from the RTD_REG in one shot mode
+    @return The raw unsigned 16-bit value, NOT temperature!
+*/
+/**************************************************************************/
+uint16_t Adafruit_MAX31865::readRTDGet(void) {
   uint16_t rtd = readRegister16(MAX31865_RTDMSB_REG);
 
-  enableBias(false); // Disable bias current again to reduce selfheating.
+  enableBias(false);  // Disable bias current again to reduce selfheating.
 
   // remove fault
   rtd >>= 1;

--- a/Adafruit_MAX31865.cpp
+++ b/Adafruit_MAX31865.cpp
@@ -256,7 +256,7 @@ void Adafruit_MAX31865::readRTDSend(void) {
 uint16_t Adafruit_MAX31865::readRTDGet(void) {
   uint16_t rtd = readRegister16(MAX31865_RTDMSB_REG);
 
-  enableBias(false);  // Disable bias current again to reduce selfheating.
+  enableBias(false); // Disable bias current again to reduce selfheating.
 
   // remove fault
   rtd >>= 1;

--- a/Adafruit_MAX31865.h
+++ b/Adafruit_MAX31865.h
@@ -72,6 +72,9 @@ public:
   uint8_t readFault(void);
   void clearFault(void);
   uint16_t readRTD();
+  void readRTDPrepare(void);
+  void readRTDSend(void);
+  uint16_t readRTDGet(void);
 
   void setWires(max31865_numwires_t wires);
   void autoConvert(bool b);
@@ -80,7 +83,7 @@ public:
 
   float temperature(float RTDnominal, float refResistor);
 
-private:
+ private:
   Adafruit_SPIDevice spi_dev;
 
   void readRegisterN(uint8_t addr, uint8_t buffer[], uint8_t n);

--- a/Adafruit_MAX31865.h
+++ b/Adafruit_MAX31865.h
@@ -83,7 +83,7 @@ public:
 
   float temperature(float RTDnominal, float refResistor);
 
- private:
+private:
   Adafruit_SPIDevice spi_dev;
 
   void readRegisterN(uint8_t addr, uint8_t buffer[], uint8_t n);


### PR DESCRIPTION
Created subfunctions can be used for better cooperative multitasking because they do not use `delay` call.