### PR TITLE
Add SPI param for alternate HW SPI

### DIFF
--- a/Adafruit_MAX31865.cpp
+++ b/Adafruit_MAX31865.cpp
@@ -44,8 +44,8 @@ Adafruit_MAX31865::Adafruit_MAX31865(int8_t spi_cs, int8_t spi_mosi,
     @param spi_cs the SPI CS pin to use along with the default SPI device
 */
 /**************************************************************************/
-Adafruit_MAX31865::Adafruit_MAX31865(int8_t spi_cs)
-    : spi_dev(spi_cs, 1000000, SPI_BITORDER_MSBFIRST, SPI_MODE1) {}
+Adafruit_MAX31865::Adafruit_MAX31865(int8_t spi_cs, SPIClass *theSPI)
+    : spi_dev(spi_cs, 1000000, SPI_BITORDER_MSBFIRST, SPI_MODE1, theSPI) {}
 
 /**************************************************************************/
 /*!

--- a/Adafruit_MAX31865.cpp
+++ b/Adafruit_MAX31865.cpp
@@ -41,7 +41,8 @@ Adafruit_MAX31865::Adafruit_MAX31865(int8_t spi_cs, int8_t spi_mosi,
 /**************************************************************************/
 /*!
     @brief Create the interface object using hardware SPI
-    @param spi_cs the SPI CS pin to use along with the default SPI device
+    @param spi_cs the SPI chip select pin to use
+    @param theSPI the SPI device to use, default is SPI
 */
 /**************************************************************************/
 Adafruit_MAX31865::Adafruit_MAX31865(int8_t spi_cs, SPIClass *theSPI)

--- a/Adafruit_MAX31865.h
+++ b/Adafruit_MAX31865.h
@@ -65,7 +65,7 @@ class Adafruit_MAX31865 {
 public:
   Adafruit_MAX31865(int8_t spi_cs, int8_t spi_mosi, int8_t spi_miso,
                     int8_t spi_clk);
-  Adafruit_MAX31865(int8_t spi_cs);
+  Adafruit_MAX31865(int8_t spi_cs, SPIClass *theSPI = &SPI);
 
   bool begin(max31865_numwires_t x = MAX31865_2WIRE);
 


### PR DESCRIPTION
For #34. Simple update to add a parameter to allow specifying an alternate HW SPI instance.

Tested with Itsy M0. Nothing fancy. Just explicitly specifying the default port.
```cpp
#include <Adafruit_MAX31865.h>

#define RREF      430.0
#define RNOMINAL  100.0

Adafruit_MAX31865 thermo = Adafruit_MAX31865(10, &SPI);


void setup() {
  Serial.begin(9600);
  while (!Serial);
  Serial.println("MAX31865 Test.");
  
  thermo.begin(MAX31865_3WIRE);
}

void loop() {
  Serial.print("Temperature = "); Serial.println(thermo.temperature(RNOMINAL, RREF));
  delay(1000);
}
```

![Screenshot from 2022-06-21 08-53-29](https://user-images.githubusercontent.com/8755041/174844470-77df6c79-fa98-4521-a490-56e4cca168c0.png)

