### PR TITLE
Add fault check cycle modes

### DIFF
--- a/Adafruit_MAX31865.cpp
+++ b/Adafruit_MAX31865.cpp
@@ -71,6 +71,9 @@ bool Adafruit_MAX31865::begin(max31865_numwires_t wires) {
 /**************************************************************************/
 /*!
     @brief Read the raw 8-bit FAULTSTAT register
+    @param fault_cycle The fault cycle type to run. Can be MAX31865_FAULT_NONE,
+   MAX31865_FAULT_AUTO, MAX31865_FAULT_MANUAL_RUN, or
+   MAX31865_FAULT_MANUAL_FINISH
     @return The raw unsigned 8-bit FAULT status register
 */
 /**************************************************************************/

--- a/Adafruit_MAX31865.cpp
+++ b/Adafruit_MAX31865.cpp
@@ -74,7 +74,26 @@ bool Adafruit_MAX31865::begin(max31865_numwires_t wires) {
     @return The raw unsigned 8-bit FAULT status register
 */
 /**************************************************************************/
-uint8_t Adafruit_MAX31865::readFault(void) {
+uint8_t Adafruit_MAX31865::readFault(max31865_fault_cycle_t fault_cycle) {
+  if (fault_cycle) {
+    uint8_t cfg_reg = readRegister8(MAX31865_CONFIG_REG);
+    cfg_reg &= 0x11; // mask out wire and filter bits
+    switch (fault_cycle) {
+    case MAX31865_FAULT_AUTO:
+      writeRegister8(MAX31865_CONFIG_REG, (cfg_reg | 0b10000100));
+      delay(1);
+      break;
+    case MAX31865_FAULT_MANUAL_RUN:
+      writeRegister8(MAX31865_CONFIG_REG, (cfg_reg | 0b10001000));
+      return 0;
+    case MAX31865_FAULT_MANUAL_FINISH:
+      writeRegister8(MAX31865_CONFIG_REG, (cfg_reg | 0b10001100));
+      return 0;
+    case MAX31865_FAULT_NONE:
+    default:
+      break;
+    }
+  }
   return readRegister8(MAX31865_FAULTSTAT_REG);
 }
 

--- a/Adafruit_MAX31865.h
+++ b/Adafruit_MAX31865.h
@@ -60,6 +60,13 @@ typedef enum max31865_numwires {
   MAX31865_4WIRE = 0
 } max31865_numwires_t;
 
+typedef enum {
+  MAX31865_FAULT_NONE = 0,
+  MAX31865_FAULT_AUTO,
+  MAX31865_FAULT_MANUAL_RUN,
+  MAX31865_FAULT_MANUAL_FINISH
+} max31865_fault_cycle_t;
+
 /*! Interface class for the MAX31865 RTD Sensor reader */
 class Adafruit_MAX31865 {
 public:
@@ -69,7 +76,7 @@ public:
 
   bool begin(max31865_numwires_t x = MAX31865_2WIRE);
 
-  uint8_t readFault(void);
+  uint8_t readFault(max31865_fault_cycle_t fault_cycle = MAX31865_FAULT_AUTO);
   void clearFault(void);
   uint16_t readRTD();
 


### PR DESCRIPTION
For #5 and #27.

The datasheet makes it pretty clear that a fault detection cycle must be initiated to actually check for certain faults. This was totally missing from the library. And there are a few options for how to run the cycle. Enums added for the options with default being auto. It's not super clear how the manual option should be run in user code, there's like two steps. But enums for those are included as well. Can also choose none, since the auto cycle is slightly blocking.

Also not seeing anything in datasheet to indicate this comment for #27. So, for now, nothing new added to `::begin()`.

> According to the MAX31865 data sheet (page 14) a manual or automatic fault detection cycle must be run at startup.
> Without that the startup of the MAX31865 behaves arbitrarily and can prevent data reading,


Here's test sketch:
```cpp
#include <Adafruit_MAX31865.h>

#define RREF      430.0
#define RNOMINAL  100.0

Adafruit_MAX31865 thermo = Adafruit_MAX31865(10);

void setup() {
  Serial.begin(9600);
  while (!Serial);
  Serial.println("MAX31865 Fault Test.");
  
  thermo.begin(MAX31865_3WIRE); 
}

void loop() {
  // Check and print any faults
  uint8_t fault = thermo.readFault();
  if (fault) {
    Serial.print("Fault 0x"); Serial.println(fault, HEX);
    if (fault & MAX31865_FAULT_HIGHTHRESH) {
      Serial.println("RTD High Threshold"); 
    }
    if (fault & MAX31865_FAULT_LOWTHRESH) {
      Serial.println("RTD Low Threshold"); 
    }
    if (fault & MAX31865_FAULT_REFINLOW) {
      Serial.println("REFIN- > 0.85 x Bias"); 
    }
    if (fault & MAX31865_FAULT_REFINHIGH) {
      Serial.println("REFIN- < 0.85 x Bias - FORCE- open"); 
    }
    if (fault & MAX31865_FAULT_RTDINLOW) {
      Serial.println("RTDIN- < 0.85 x Bias - FORCE- open"); 
    }
    if (fault & MAX31865_FAULT_OVUV) {
      Serial.println("Under/Over voltage"); 
    }
    thermo.clearFault();
  }
}
```

and running with one of the RTD wires disconnected:
![Screenshot from 2022-06-29 16-12-23](https://user-images.githubusercontent.com/8755041/176561720-e1715c3e-e797-4d13-a462-f16e423c6c8d.png)


