### PR TITLE
Update max31865.ino

### DIFF
--- a/examples/max31865/max31865.ino
+++ b/examples/max31865/max31865.ino
@@ -14,6 +14,7 @@
   BSD license, all text above must be included in any redistribution
  ****************************************************/
 
+#include <Adafruit_SPIDevice.h>
 #include <Adafruit_MAX31865.h>
 
 // Use software SPI: CS, DI, DO, CLK


### PR DESCRIPTION
PlatformIO build fails without including this (#include <Adafruit_SPIDevice.h>) library before MAX31865 include. Fixes the following error:
```
 #include <Wire.h>
          ^~~~~~~~
compilation terminated.
*** [.pio\build\esp32-s3-devkitc-1\lib68d\Adafruit BusIO\Adafruit_I2CDevice.cpp.o] Error 1
*** [.pio\build\esp32-s3-devkitc-1\lib68d\Adafruit BusIO\Adafruit_BusIO_Register.cpp.o] Error 1

```

